### PR TITLE
Fix/cors header

### DIFF
--- a/api-backend.js
+++ b/api-backend.js
@@ -4,7 +4,7 @@ export default async function handler(req, res) {
 
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization"); 
   
     const headers = {
       Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -25,7 +25,7 @@ export default async function handler(req, res) {
       // 2. Fetch members (both public and private)
       const membersResponse = await fetch(`https://api.github.com/orgs/${ORG_NAME}/members?per_page=100`, {
         headers,
-      });
+      });                                                                                   
       const membersData = await membersResponse.json();
   
       if (!Array.isArray(membersData)) {

--- a/api-backend.js
+++ b/api-backend.js
@@ -1,6 +1,10 @@
 export default async function handler(req, res) {
     const GITHUB_TOKEN = process.env.GITHUB_TOKEN; // From Vercel
     const ORG_NAME = "Krypto-Hashers-Community";
+
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
   
     const headers = {
       Authorization: `Bearer ${GITHUB_TOKEN}`,


### PR DESCRIPTION
## Fix: Add CORS headers to resolve cross-origin request issues

*Firstly, ty for inviting me to the community! 💯*

<br />

When trying to access the API from a frontend app, browsers throw this error:

```Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at [https://github-api-backend.vercel.app/api/github-data](https://github-api-backend.vercel.app/api/github-data)```

This happens because browsers block requests between different domains by default for security reasons 


So, I added the necessary CORS headers to let browsers know they can safely make requests to our API from any frontend domain.

### Changes made:
- Added `Access-Control-Allow-Origin: *` to allow requests from any domain
- Added `Access-Control-Allow-Methods: GET, OPTIONS` for the HTTP methods we use
- Added `Access-Control-Allow-Headers: Content-Type, Authorization` for the headers we send

**Note:** couldn't test the actual frontend integration since I don't have Vercel access, but in my perspective the CORS implementation follows standard practices and should work perfectly